### PR TITLE
Add support for zero timeout, for a non blocking reserve operation

### DIFF
--- a/src/main/java/com/dinstone/beanstalkc/JobConsumer.java
+++ b/src/main/java/com/dinstone/beanstalkc/JobConsumer.java
@@ -36,7 +36,7 @@ public interface JobConsumer {
      * available.
      * 
      * @param timeout
-     *        if timeout>0,then with reserve-with-timeout command.
+     *        if timeout >= 0, then with reserve-with-timeout command.
      * @return
      */
     public Job reserveJob(long timeout);

--- a/src/main/java/com/dinstone/beanstalkc/internal/operation/ReserveOperation.java
+++ b/src/main/java/com/dinstone/beanstalkc/internal/operation/ReserveOperation.java
@@ -40,7 +40,7 @@ public class ReserveOperation extends AbstractOperation<Job> {
     public ReserveOperation(long timeout) {
         super(new OperationFuture<Job>());
 
-        if (timeout > 0) {
+        if (timeout >= 0) {
             this.command = "reserve-with-timeout " + timeout;
         } else {
             this.command = "reserve";


### PR DESCRIPTION
This is part of the beanstalk docs, and is also copied to `JobConsumer`.

```
     * beanstalkd will wait to send a response until one becomes available. Once
     * a job is reserved for the client, the client has limited time to run
     * (TTR) the job before the job times out. When the job times out, the
     * server will put the job back into the ready queue. Both the TTR and the
     * actual time left can be found in response to the stats-job command. A
     * timeout value of 0 will cause the server to immediately return either a
     * response or TIMED_OUT. A positive value of timeout will limit the amount
     * of time the client will block on the reserve request until a job becomes
     * available.
```

This PR add support for this documented behaviour to support non blocking reserve operations.
